### PR TITLE
Fix compilation error and several warnings

### DIFF
--- a/src/Chrom3D.cpp
+++ b/src/Chrom3D.cpp
@@ -193,7 +193,6 @@ int main(int argc, char** argv) {
 
   MCMC mcmc(model);
   bool success;
-  uint Niter=args.nIter;
   double maxTemp = args.maxtemp;
   double coolRate = args.coolrate; // Number between 0 and 1, giving the rate of cooling at each step
   double temp=maxTemp;

--- a/src/Chrom3D.cpp
+++ b/src/Chrom3D.cpp
@@ -11,15 +11,13 @@
 #include <math.h>
 #include <limits>
 #include <stdexcept>
+#include <string>
 
 #include <sstream>
 
 //#include <boost/filesystem.hpp>
 
 #include "../src/tclap-1.2.1/include/tclap/CmdLine.h"
-
-#define SSTR( x ) dynamic_cast< std::ostringstream & >( \
-        ( std::ostringstream() << std::dec << x ) ).str()
 
 using namespace std;
 
@@ -215,7 +213,7 @@ cerr << "0 " << model.getLossScore() << endl;
     assert(success);
     if (i % verbosity == 0) {
       if(args.printStructures) {
-	model.writeCMM(args.modelName + "_iter_" + SSTR(i) + ".cmm");
+	model.writeCMM(args.modelName + "_iter_" + std::to_string(i) + ".cmm");
       }
       //cerr << i << " " << model.getLossScore(INTERACTION_INTRA) << " " << model.getLossScore(INTERACTION_INTER) << " " << model.getLossScore(PERIPHERY) << " " << model.getLossScore(CENTER) << " " << model.getLossScore(INTERACTION_DIST) << " " << model.getLossScore() << endl;
       cerr << i << " " << model.getLossScore() << endl;

--- a/src/Chrom3D.cpp
+++ b/src/Chrom3D.cpp
@@ -192,10 +192,11 @@ int main(int argc, char** argv) {
   //model.buildHashMap();
 
   MCMC mcmc(model);
-  bool success;
   double maxTemp = args.maxtemp;
   double coolRate = args.coolrate; // Number between 0 and 1, giving the rate of cooling at each step
   double temp=maxTemp;
+  bool success;
+  (void)success; // [[maybe_unused]]
 
   uint verbosity = (args.verbose == 0) ? args.nIter+1 : args.verbose;
 

--- a/src/Chromosome.h
+++ b/src/Chromosome.h
@@ -43,7 +43,6 @@ class Chromosome {
   friend bool operator!=(const Chromosome&, const Chromosome&);
   void setColor(double, double, double);
  private:
-  bool fixed;
   std::string name;
   //std::vector<Bead> beadList;
   boost::container::static_vector<Bead,MAXSIZE> beadList;

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -962,7 +962,6 @@ void Model::rescaleBeadSizes(double occupancyFactor) {
   assert(this->hasNucleus);
   vector<Chromosome>::iterator chriter;
   boost::container::static_vector<Bead,MAXSIZE>::iterator beaditer;
-  double beadVol = this->getTotalBeadVolume();
   double genomeLength = this->getTotalGenomeLength();
   for(chriter = chromosomes.begin(); chriter != chromosomes.end(); chriter++) {
     for(beaditer=chriter->begin(); beaditer!=chriter->end(); beaditer++) {

--- a/src/Randomizer.h
+++ b/src/Randomizer.h
@@ -24,6 +24,7 @@ class Move {
 class Randomizer {
  public:
   virtual Move randomize(Chromosome&, ENG&) = 0;
+  virtual ~Randomizer() noexcept = default;
 };
 
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -68,7 +68,7 @@ namespace util {
   class MoveException: public std::exception {
   public:
     MoveException();
-    const char* what(){return "Unacceptable move!";}
+    virtual const char* what() const noexcept {return "Unacceptable move!";}
   };
 
 }


### PR DESCRIPTION
Compiling Chrom3D with GCC 12 fails with the following error:

```
g++ -O3 -I src/tclap-1.2.1/include src/Util.cpp src/Bead.cpp src/Chromosome.cpp src/Randomizer.cpp src/Constraint.cpp src/Model.cpp src/MCMC.cpp src/Chrom3D.cpp -o Chrom3D
src/Chrom3D.cpp: In function ‘int main(int, char**)’:
src/Chrom3D.cpp:21:19: error: invalid ‘static_cast’ from type ‘std::__cxx11::basic_ostringstream<char>’ to type ‘std::ostringstream&’ {aka ‘std::__cxx11::basic_ostringstream<char>&’}
   21 | #define SSTR( x ) dynamic_cast< std::ostringstream & >( \
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   22 |         ( std::ostringstream() << std::dec << x ) ).str()
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/Chrom3D.cpp:21:19: note: in definition of macro ‘SSTR’
   21 | #define SSTR( x ) dynamic_cast< std::ostringstream & >( \
      |                   ^~~~~~~~~~~~
make: *** [Makefile:6: all] Error 1
```

This PR replaces the `SSTR` macro with `std::to_string()` (available since C++11 - [docs](https://en.cppreference.com/w/cpp/string/basic_string/to_string)). Closes #35

The PR also addresses warnings raised by GCC 12 and Clang 14 due to the warnings enabled by https://github.com/Chrom3D/Chrom3D/pull/37.