### PR TITLE
Update Makefile to enable more warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ SRCPATH=src
 TCLAPINCLUDE=src/tclap-1.2.1/include
 
 all:
-	g++ -O3 -I $(TCLAPINCLUDE) $(SRCPATH)/Util.cpp $(SRCPATH)/Bead.cpp $(SRCPATH)/Chromosome.cpp $(SRCPATH)/Randomizer.cpp $(SRCPATH)/Constraint.cpp $(SRCPATH)/Model.cpp $(SRCPATH)/MCMC.cpp $(SRCPATH)/Chrom3D.cpp -o Chrom3D
+	g++ -Wall -Wextra -Wsign-compare -Wunused -Wpedantic -Wnull-dereference -O3 -I $(TCLAPINCLUDE) $(SRCPATH)/Util.cpp $(SRCPATH)/Bead.cpp $(SRCPATH)/Chromosome.cpp $(SRCPATH)/Randomizer.cpp $(SRCPATH)/Constraint.cpp $(SRCPATH)/Model.cpp $(SRCPATH)/MCMC.cpp $(SRCPATH)/Chrom3D.cpp -o Chrom3D
 


### PR DESCRIPTION
This PR enables the following compiler warnings:

- `-Wall`
- `-Wextra`
- `-Wsign-compare`
- `-Wunused`
- `-Wpedantic`
- `-Wnull-dereference`

All warnings except `-Wnull-dereference` are available on very old versions of GCC (e.g. GCC 4.8.0, released in March 2013).

`-Wnull-dereference` was introduced with GCC 7.1 (released in May 2017).
We can drop this warning if compatibility with very old versions of GCC is important.