### PR TITLE
Add support for CMake

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,12 @@
+# Copyright (C) 2022 Roberto Rossini <roberros@uio.no>
+#
+# SPDX-License-Identifier: MIT
+bullet_char: '*'
+dangle_parens: false
+enum_char: .
+line_ending: unix
+line_width: 120
+max_pargs_hwrap: 3
+separate_ctrl_name_with_space: false
+separate_fn_name_with_space: false
+tab_size: 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,10 @@ endif()
 add_executable(Chrom3D)
 
 target_compile_features(Chrom3D PRIVATE cxx_std_${CMAKE_CXX_STANDARD})
-set_target_properties(Chrom3D PROPERTIES INTERPROCEDURAL_OPTIMIZATION ${CMAKE_INTERPROCEDURAL_OPTIMIZATION})
+
+if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+  set_target_properties(Chrom3D PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
+endif()
 
 target_sources(
   Chrom3D

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,41 @@ set(COMPILER_WARNINGS
     -Wnull-dereference)
 target_compile_options(Chrom3D PRIVATE ${COMPILER_WARNINGS})
 
+# Add options to enable/disable sanitizers
+option(ENABLE_SANITIZER_ADDRESS "Enable ASAN" OFF)
+option(ENABLE_SANITIZER_ADDRESS "Enable LSAN" OFF)
+option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR "Enable UBSAN" OFF)
+
+set(SANITIZERS "")
+
+if(ENABLE_SANITIZER_ADDRESS)
+  set(SANITIZERS "address")
+endif()
+
+if(ENABLE_SANITIZER_LEAK)
+  if("${SANITIZERS}" STREQUAL "")
+    set(SANITIZERS "leak")
+  else()
+    set(SANITIZERS "${SANITIZERS},leak")
+  endif()
+endif()
+
+if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOR)
+  if("${SANITIZERS}" STREQUAL "")
+    set(SANITIZERS "undefined")
+  else()
+    set(SANITIZERS "${SANITIZERS},undefined")
+  endif()
+endif()
+
+if(NOT
+   "${SANITIZERS}"
+   STREQUAL
+   "")
+  target_compile_options(Chrom3D PRIVATE -fsanitize=${SANITIZERS})
+  target_link_options(Chrom3D PRIVATE -fsanitize=${SANITIZERS})
+endif()
+
 include(GNUInstallDirs)
 
 install(TARGETS Chrom3D BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE
-      "RelWithDebInfo"
+      "Release"
       CACHE STRING "" FORCE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,69 @@
+# Copyright (C) 2022 Roberto Rossini <roberros@uio.no>
+#
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.9)
+
+project(Chrom3D LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE
+      "RelWithDebInfo"
+      CACHE STRING "" FORCE)
+endif()
+
+if(NOT BUILD_SHARED_LIBS)
+  set(Boost_USE_STATIC_LIBS ON)
+endif()
+find_package(Boost 1.54.0 REQUIRED COMPONENTS filesystem random)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT result OUTPUT output)
+  if(result)
+    message(STATUS "Enabling Interprocedural optimization")
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+
+  else()
+    message(WARNING "Interprocedural Optimization is not supported. Disabling it!")
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
+  endif()
+endif()
+
+add_executable(Chrom3D)
+
+target_compile_features(Chrom3D PRIVATE cxx_std_${CMAKE_CXX_STANDARD})
+set_target_properties(Chrom3D PROPERTIES INTERPROCEDURAL_OPTIMIZATION ${CMAKE_INTERPROCEDURAL_OPTIMIZATION})
+
+target_sources(
+  Chrom3D
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/Bead.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/Chrom3D.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/Chromosome.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/Constraint.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/MCMC.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/Model.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/Randomizer.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/Util.cpp)
+
+target_include_directories(Chrom3D PRIVATE src/ src/tclap-1.2.1/include/)
+
+target_link_libraries(Chrom3D PUBLIC m Boost::headers Boost::random)
+
+set(COMPILER_WARNINGS
+    -Wall
+    -Wextra
+    -Wsign-compare
+    -Wunused
+    -Wpedantic
+    -Wnull-dereference)
+target_compile_options(Chrom3D PRIVATE ${COMPILER_WARNINGS})
+
+include(GNUInstallDirs)
+
+install(TARGETS Chrom3D BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES LICENCE DESTINATION share/licenses/Chrom3D/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 find_package(Boost 1.54.0 REQUIRED COMPONENTS filesystem random)
 
+# Try to enable IPO when compiling in Release
 if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   include(CheckIPOSupported)
   check_ipo_supported(RESULT result OUTPUT output)
@@ -36,11 +37,7 @@ endif()
 
 add_executable(Chrom3D)
 
-target_compile_features(Chrom3D PRIVATE cxx_std_${CMAKE_CXX_STANDARD})
-
-if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
-  set_target_properties(Chrom3D PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
-endif()
+target_include_directories(Chrom3D PRIVATE src/ src/tclap-1.2.1/include/)
 
 target_sources(
   Chrom3D
@@ -53,9 +50,13 @@ target_sources(
           ${CMAKE_CURRENT_SOURCE_DIR}/src/Randomizer.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/src/Util.cpp)
 
-target_include_directories(Chrom3D PRIVATE src/ src/tclap-1.2.1/include/)
-
 target_link_libraries(Chrom3D PUBLIC m Boost::headers Boost::random)
+
+target_compile_features(Chrom3D PRIVATE cxx_std_${CMAKE_CXX_STANDARD})
+
+if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+  set_target_properties(Chrom3D PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
+endif()
 
 set(COMPILER_WARNINGS
     -Wall


### PR DESCRIPTION
This PR adds a `CMakeFiles.txt` so that Chrom3D can be built using CMake.
CMake 3.9 or newer is required (CMake 3.9 was released back in 2017)

This should alleviate some of the pain related to installing and detecting Boost.

The project can be built as follows:

```bash
mkdir build
cd build

cmake ..
cmake --build . -j8  # Optional: change this to the number of available CPU cores

# Install Chrom3D under /usr/local (optional)
cmake --install . 

# Alternative: install Chrom3D under a custom path (also optional)
cmake --install . --prefix ~/.local/
```

In the first case, Chrom3D executable will be located at `/usr/local/bin/Chrom3D`,
while in the second case the executable can be found at `~/.local/bin/Chrom3D`

By default Chrom3D is statically linked, so Boost can in principle be uninstalled after successfully compiling Chrom3D.